### PR TITLE
mp4san: disable failing gpac tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,20 +53,13 @@ jobs:
       - name: install libav libraries for ffmpeg tests
         run:  sudo apt-get install --no-install-recommends -y libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev
 
-      - name: install gpac libraries for gpac tests
-        run: |
-          wget https://download.tsi.telecom-paristech.fr/gpac/release/2.2/gpac_2.2-rev0-gab012bbf-master_amd64.deb
-          sudo apt-get install ./gpac_2.2-rev0-gab012bbf-master_amd64.deb
-          wget https://download.tsi.telecom-paristech.fr/gpac/release/2.2/libgpac-dev_2.2-rev0-gab012bbf-master_amd64.deb
-          sudo apt-get install ./libgpac-dev_2.2-rev0-gab012bbf-master_amd64.deb
-
       - name: cargo test -- --skip test_data
-        run:  cargo test --verbose --features mp4san-test/ffmpeg,mp4san-test/gpac,webpsan-test/libwebp -- --skip test_data
+        run:  cargo test --verbose --features mp4san-test/ffmpeg,webpsan-test/libwebp -- --skip test_data
 
       - name: cargo test test_data
         continue-on-error: true
         if: ${{ env.TEST_DATA_SSH_KEY != '' }}
-        run:  cargo test --verbose --features mp4san-test/ffmpeg,mp4san-test/gpac,webpsan-test/libwebp test_data -- --show-output
+        run:  cargo test --verbose --features mp4san-test/ffmpeg,webpsan-test/libwebp test_data -- --show-output
 
       - name: cargo clippy
         uses: actions-rs/clippy-check@v1


### PR DESCRIPTION
The gpac tests have a history of failing sporadically (see [this build log](https://github.com/signalapp/mp4san/actions/runs/7729627316/job/21073251855) for example) there seems to be some UB in the use of gpac for those tests, likely to do with the FFI. Let's disable them until we track the problem down.