### PR TITLE
mediasan-cli: add output argument

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,8 +1,12 @@
+use std::fs;
 use std::fs::File;
+use std::io;
+use std::io::{Read, Seek, Write};
 use std::path::PathBuf;
 
 use anyhow::Context;
 use clap::{Parser as _, ValueEnum};
+use mp4san::SanitizedMetadata;
 
 #[derive(clap::Parser)]
 struct Args {
@@ -11,6 +15,10 @@ struct Args {
     /// If not specified, a guess will be made based on the file extension.
     #[clap(long, short = 't')]
     format: Option<Format>,
+
+    /// Path to the file to write sanitized output.
+    #[clap(long, short = 'o')]
+    output: Option<PathBuf>,
 
     /// Path to the file to test sanitization on.
     file: PathBuf,
@@ -40,12 +48,33 @@ fn main() -> Result<(), anyhow::Error> {
         }
     };
 
-    let file = File::open(args.file).context("Error opening file")?;
+    let mut infile = File::open(&args.file).context("Error opening file")?;
 
     match format {
-        Format::Mp4 => mp4san::sanitize(file).map(drop).context("Error parsing mp4 file")?,
-        Format::Webp => webpsan::sanitize(file).context("Error parsing webp file")?,
-    }
+        Format::Mp4 => match mp4san::sanitize(&mut infile).context("Error parsing mp4 file")? {
+            SanitizedMetadata { metadata: Some(metadata), data } => {
+                if let Some(output_path) = args.output {
+                    let mut outfile = File::create(output_path).context("Error opening output file")?;
+                    outfile.write(&metadata).context("Error writing output")?;
+                    infile
+                        .seek(io::SeekFrom::Start(data.offset))
+                        .context("Error seeking input")?;
+                    io::copy(&mut infile.take(data.len), &mut outfile).context("Error copying input to output")?;
+                }
+            }
+            SanitizedMetadata { metadata: None, .. } => {
+                if let Some(output_path) = args.output {
+                    fs::copy(&args.file, output_path).context("Error writing output")?;
+                }
+            }
+        },
+        Format::Webp => {
+            webpsan::sanitize(infile).context("Error parsing webp file")?;
+            if let Some(output_path) = args.output {
+                fs::copy(args.file, output_path).context("Error writing output")?;
+            }
+        }
+    };
 
     Ok(())
 }


### PR DESCRIPTION
Adds an `--output` argument to `mediasan-cli`, useful to run full end-to-end testing.