### PR TITLE
Milan/sanitizing cumulative box sized files

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,7 @@ struct Args {
     output: Option<PathBuf>,
 
     #[clap(long, short = 'c')]
-    cumulative_mdat_box_size: Option<u64>,
+    cumulative_mdat_box_size: Option<u32>,
 
     /// Path to the file to test sanitization on.
     file: PathBuf,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), anyhow::Error> {
         Format::Mp4 => {
             let analysis_result = match args.cumulative_mdat_box_size {
                 Some(t) => {
-                    let config = Config { cumulative_mdat_box_size: t, ..Default::default() };
+                    let config = Config { cumulative_mdat_box_size: Some(t), ..Default::default() };
                     mp4san::sanitize_with_config(&mut infile, config).context("Error parsing mp4 file")?
                 }
                 None => mp4san::sanitize(&mut infile).context("Error parsing mp4 file")?,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -55,14 +55,11 @@ fn main() -> Result<(), anyhow::Error> {
 
     match format {
         Format::Mp4 => {
-            let analysis_result = match args.cumulative_mdat_box_size {
-                Some(t) => {
-                    let config = Config { cumulative_mdat_box_size: Some(t), ..Default::default() };
-                    mp4san::sanitize_with_config(&mut infile, config).context("Error parsing mp4 file")?
-                }
-                None => mp4san::sanitize(&mut infile).context("Error parsing mp4 file")?,
+            let config = match args.cumulative_mdat_box_size {
+                Some(t) => Config { cumulative_mdat_box_size: Some(t), ..Default::default() },
+                None => Config::default(),
             };
-            match analysis_result {
+            match mp4san::sanitize_with_config(&mut infile, config).context("Error parsing mp4 file")? {
                 SanitizedMetadata { metadata: Some(metadata), data } => {
                     if let Some(output_path) = args.output {
                         let mut outfile = File::create(output_path).context("Error opening output file")?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -53,19 +53,13 @@ fn main() -> Result<(), anyhow::Error> {
 
     let mut infile = File::open(&args.file).context("Error opening file")?;
 
-    let _cumulative_mdat_box_size = match args.cumulative_mdat_box_size {
-        Some(t) => t,
-        None => 0,
-    };
-
     match format {
         Format::Mp4 => {
             let analysis_result = match args.cumulative_mdat_box_size {
                 Some(t) => {
-                    let mut config = Config::default();
-                    config.cumulative_mdat_box_size = t;
+                    let config = Config { cumulative_mdat_box_size: t, ..Default::default() };
                     mp4san::sanitize_with_config(&mut infile, config).context("Error parsing mp4 file")?
-                },
+                }
                 None => mp4san::sanitize(&mut infile).context("Error parsing mp4 file")?,
             };
             match analysis_result {
@@ -85,7 +79,7 @@ fn main() -> Result<(), anyhow::Error> {
                     }
                 }
             }
-        },
+        }
         Format::Webp => {
             webpsan::sanitize(infile).context("Error parsing webp file")?;
             if let Some(output_path) = args.output {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,6 +20,9 @@ struct Args {
     #[clap(long, short = 'o')]
     output: Option<PathBuf>,
 
+    #[clap(long, short = 'c')]
+    cumulative_mdat_box_size: Option<u64>,
+
     /// Path to the file to test sanitization on.
     file: PathBuf,
 }
@@ -49,6 +52,11 @@ fn main() -> Result<(), anyhow::Error> {
     };
 
     let mut infile = File::open(&args.file).context("Error opening file")?;
+
+    let _cumulative_mdat_box_size = match args.cumulative_mdat_box_size {
+        Some(t) => t,
+        None => 0,
+    };
 
     match format {
         Format::Mp4 => match mp4san::sanitize(&mut infile).context("Error parsing mp4 file")? {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -55,10 +55,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     match format {
         Format::Mp4 => {
-            let config = match args.cumulative_mdat_box_size {
-                Some(t) => Config { cumulative_mdat_box_size: Some(t), ..Default::default() },
-                None => Config::default(),
-            };
+            let config = Config { cumulative_mdat_box_size: args.cumulative_mdat_box_size, ..Default::default() };
             match mp4san::sanitize_with_config(&mut infile, config).context("Error parsing mp4 file")? {
                 SanitizedMetadata { metadata: Some(metadata), data } => {
                     if let Some(output_path) = args.output {

--- a/mp4san-test-gen/src/main.rs
+++ b/mp4san-test-gen/src/main.rs
@@ -34,14 +34,14 @@ fn main() -> Result<(), anyhow::Error> {
         reader
             .read_exact(&mut header_data)
             .context("Error reading input file")?;
-        let header = match BoxHeader::parse(&header_data[..], 0) {
+        let header = match BoxHeader::parse(&header_data[..]) {
             Ok(header) => header,
             Err(_) => {
                 header_data.extend([0; 8]);
                 reader
                     .read_exact(&mut header_data[8..])
                     .context("Error reading input file")?;
-                BoxHeader::parse(&header_data[..], 0).context("Error reading input file")?
+                BoxHeader::parse(&header_data[..]).context("Error reading input file")?
             }
         };
         encoder.write_all(&header_data).context("Error writing to output")?;

--- a/mp4san-test-gen/src/main.rs
+++ b/mp4san-test-gen/src/main.rs
@@ -34,14 +34,14 @@ fn main() -> Result<(), anyhow::Error> {
         reader
             .read_exact(&mut header_data)
             .context("Error reading input file")?;
-        let header = match BoxHeader::parse(&header_data[..]) {
+        let header = match BoxHeader::parse(&header_data[..], 0) {
             Ok(header) => header,
             Err(_) => {
                 header_data.extend([0; 8]);
                 reader
                     .read_exact(&mut header_data[8..])
                     .context("Error reading input file")?;
-                BoxHeader::parse(&header_data[..]).context("Error reading input file")?
+                BoxHeader::parse(&header_data[..], 0).context("Error reading input file")?
             }
         };
         encoder.write_all(&header_data).context("Error writing to output")?;

--- a/mp4san/src/lib.rs
+++ b/mp4san/src/lib.rs
@@ -832,4 +832,14 @@ mod test {
             assert_matches!(err.into_inner(), ParseError::InvalidBoxLayout);
         });
     }
+
+    #[test]
+    fn cumulative_mdat_box_size() {
+        let test_spec = test_mp4().mdat_data_until_eof().build_spec().unwrap();
+        let config = Config::builder()
+            .max_metadata_size(test_spec.moov().build().encoded_len())
+            .cumulative_mdat_box_size(Some(14))
+            .build();
+        test_spec.build().sanitize_ok_with_config(config);
+    }
 }

--- a/mp4san/src/lib.rs
+++ b/mp4san/src/lib.rs
@@ -839,11 +839,9 @@ mod test {
         let test_1 = test_spec.build();
         let mdat_box_length = test_1.mdat.len as u32;
 
-        let config_bad = Config::builder()
-            .cumulative_mdat_box_size(Some(mdat_box_length + 1))
-            .build();
+        let config_bad = Config::builder().build();
         assert_matches!(sanitize_with_config(test_1, config_bad).unwrap_err(), Error::Parse(err) => {
-            assert_matches!(err.into_inner(), ParseError::TruncatedBox);
+            assert_matches!(err.into_inner(), ParseError::MissingRequiredBox(_));
         });
 
         let test_2 = test_spec.build();

--- a/mp4san/src/lib.rs
+++ b/mp4san/src/lib.rs
@@ -105,8 +105,14 @@ pub struct Config {
     ///       fixed zero value
     ///    b) keeps accumulating the box size and passes
     ///       it as config argument to mp4sanitizer
+    ///
+    /// IMPORTANT: given the special circumstances of
+    /// the use case scenario of transcoding on mobile
+    /// devices, the MDAT box size is expected to not
+    /// exceed the 32-bit max bytes limit. Hence the
+    /// cumulative_mdat_box_size is a 32-bit value
     #[builder(default = None)]
-    pub cumulative_mdat_box_size: Option<u64>,
+    pub cumulative_mdat_box_size: Option<u32>,
 }
 
 /// Sanitized metadata returned by the sanitizer.

--- a/mp4san/src/lib.rs
+++ b/mp4san/src/lib.rs
@@ -105,8 +105,8 @@ pub struct Config {
     ///       fixed zero value
     ///    b) keeps accumulating the box size and passes
     ///       it as config argument to mp4sanitizer
-    #[builder(default = 0)]
-    pub cumulative_mdat_box_size: u64,
+    #[builder(default = None)]
+    pub cumulative_mdat_box_size: Option<u64>,
 }
 
 /// Sanitized metadata returned by the sanitizer.
@@ -323,8 +323,8 @@ pub async fn sanitize_async_with_config<R: AsyncRead + AsyncSkip>(
             }
 
             BoxType::MDAT => {
-                if config.cumulative_mdat_box_size != 0 {
-                    header.overwrite_size(config.cumulative_mdat_box_size);
+                if let Some(t) = config.cumulative_mdat_box_size {
+                    header.overwrite_size(t);
                 }
 
                 let box_size = skip_box(reader.as_mut(), &header).await? + header.encoded_len();

--- a/mp4san/src/lib.rs
+++ b/mp4san/src/lib.rs
@@ -105,7 +105,7 @@ pub struct Config {
     ///       fixed zero value
     ///    b) keeps accumulating the box size and passes
     ///       it as config argument to mp4sanitizer
-    #[builder(default = 16672445)]
+    #[builder(default = 0)]
     pub cumulative_mdat_box_size: u64,
 }
 

--- a/mp4san/src/lib.rs
+++ b/mp4san/src/lib.rs
@@ -329,8 +329,10 @@ pub async fn sanitize_async_with_config<R: AsyncRead + AsyncSkip>(
             }
 
             BoxType::MDAT => {
-                if let Some(t) = config.cumulative_mdat_box_size {
-                    header.overwrite_size(t);
+                if let Ok(None) = header.box_data_size() {
+                    if let Some(t) = config.cumulative_mdat_box_size {
+                        header.overwrite_size(t);
+                    }
                 }
 
                 let box_size = skip_box(reader.as_mut(), &header).await? + header.encoded_len();

--- a/mp4san/src/parse/header.rs
+++ b/mp4san/src/parse/header.rs
@@ -132,7 +132,11 @@ impl BoxHeader {
     }
 
     pub fn overwrite_size(&mut self, actual_box_size: u64) {
-        self.box_size = BoxSize::Size(actual_box_size as u32);
+        if let Ok(t) = u32::try_from(actual_box_size) {
+            self.box_size = BoxSize::Size(t);
+        } else {
+            self.box_size = BoxSize::Ext(actual_box_size);
+        }
     }
 
     pub const fn encoded_len(&self) -> u64 {

--- a/mp4san/src/parse/header.rs
+++ b/mp4san/src/parse/header.rs
@@ -132,6 +132,7 @@ impl BoxHeader {
     }
 
     pub fn overwrite_size(&mut self, actual_box_size: u32) {
+        assert_eq!(self.box_size, BoxSize::UntilEof);
         self.box_size = BoxSize::Size(actual_box_size);
     }
 

--- a/mp4san/src/parse/header.rs
+++ b/mp4san/src/parse/header.rs
@@ -91,8 +91,8 @@ impl BoxHeader {
         Self { box_type, box_size: BoxSize::UntilEof }
     }
 
-    pub fn parse<B: Buf + Unpin>(input: B) -> Result<Self, ParseError> {
-        Self::read(buf_async_reader(input))
+    pub fn parse<B: Buf + Unpin>(input: B, cumulative_mdat_box_size: u64) -> Result<Self, ParseError> {
+        Self::read(buf_async_reader(input), cumulative_mdat_box_size)
             .now_or_never()
             .unwrap()
             .map_err(|err| {
@@ -101,7 +101,7 @@ impl BoxHeader {
             })
     }
 
-    pub(crate) async fn read<R: AsyncRead>(input: R) -> io::Result<Self> {
+    pub(crate) async fn read<R: AsyncRead>(input: R, cumulative_mdat_box_size: u64) -> io::Result<Self> {
         pin_mut!(input);
 
         let mut size = [0; 4];
@@ -110,7 +110,13 @@ impl BoxHeader {
         let name = FourCC::read(&mut input).await?;
 
         let size = match u32::from_be_bytes(size) {
-            0 => BoxSize::UntilEof,
+            0 => {
+                if cumulative_mdat_box_size != 0 {
+                    BoxSize::Size(cumulative_mdat_box_size as u32)
+                } else {
+                    BoxSize::UntilEof
+                }
+            }
             1 => {
                 let mut size = [0; 8];
                 input.read_exact(&mut size).await?;

--- a/mp4san/src/parse/header.rs
+++ b/mp4san/src/parse/header.rs
@@ -131,12 +131,8 @@ impl BoxHeader {
         Ok(Self { box_type: name, box_size: size })
     }
 
-    pub fn overwrite_size(&mut self, actual_box_size: u64) {
-        if let Ok(t) = u32::try_from(actual_box_size) {
-            self.box_size = BoxSize::Size(t);
-        } else {
-            self.box_size = BoxSize::Ext(actual_box_size);
-        }
+    pub fn overwrite_size(&mut self, actual_box_size: u32) {
+        self.box_size = BoxSize::Size(actual_box_size);
     }
 
     pub const fn encoded_len(&self) -> u64 {

--- a/mp4san/src/parse/mp4box.rs
+++ b/mp4san/src/parse/mp4box.rs
@@ -127,7 +127,7 @@ impl<T: ParsedBox + ?Sized> Mp4Box<T> {
 
 impl<T: ParsedBox + ?Sized> Mp4Value for Mp4Box<T> {
     fn parse(mut buf: &mut BytesMut) -> Result<Self, ParseError> {
-        let parsed_header = BoxHeader::parse(&mut buf).attach_printable(WhileParsingType::new::<Self>())?;
+        let parsed_header = BoxHeader::parse(&mut buf, 0).attach_printable(WhileParsingType::new::<Self>())?;
         let data = BoxData::get_from_bytes_mut(buf, &parsed_header).attach_printable(WhileParsingType::new::<Self>())?;
         Ok(Self { parsed_header, data })
     }

--- a/mp4san/src/parse/mp4box.rs
+++ b/mp4san/src/parse/mp4box.rs
@@ -127,7 +127,7 @@ impl<T: ParsedBox + ?Sized> Mp4Box<T> {
 
 impl<T: ParsedBox + ?Sized> Mp4Value for Mp4Box<T> {
     fn parse(mut buf: &mut BytesMut) -> Result<Self, ParseError> {
-        let parsed_header = BoxHeader::parse(&mut buf, 0).attach_printable(WhileParsingType::new::<Self>())?;
+        let parsed_header = BoxHeader::parse(&mut buf).attach_printable(WhileParsingType::new::<Self>())?;
         let data = BoxData::get_from_bytes_mut(buf, &parsed_header).attach_printable(WhileParsingType::new::<Self>())?;
         Ok(Self { parsed_header, data })
     }


### PR DESCRIPTION
Providing the API which allows mp4san to transfigure the MP4 file produced
by the Android transcoder, featuring multiple MDAT boxes compounded into
one contiguous, whose size is set to 0 ('until the EOF') even though MOOV box
resides after it.