### PR TITLE
Bump MSRV to 1.66

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 version = "0.5.3"
 edition = "2021"
 
-rust-version = "1.61.0"
+rust-version = "1.66.0"
 
 repository = "https://github.com/privacyresearchgroup/mp4san"
 license = "MIT"


### PR DESCRIPTION
There are already usages of u32::checked_add_signed, as well as other methods stabilized in Rust 1.64. 1.66 is 2+ years old, so this shouldn't significantly impact usability.